### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,10 @@ jobs:
     name: Build
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      statuses: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/wait4x/wait4x/security/code-scanning/3](https://github.com/wait4x/wait4x/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `Build` job, specifying the minimal permissions required. Based on the operations performed in the `Build` job:
- `contents: read` is needed to access the repository's code.
- `packages: write` is required for Docker-related operations (e.g., pushing images).
- `statuses: write` might be needed for updating commit statuses.

The `permissions` block will be added at the `Build` job level to avoid affecting other jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
