### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,9 @@ on:
     branches:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Check


### PR DESCRIPTION
Potential fix for [https://github.com/wait4x/wait4x/security/code-scanning/1](https://github.com/wait4x/wait4x/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking code formatting, running tests, and generating coverage reports, it only requires `contents: read` permissions. This will restrict the `GITHUB_TOKEN` to read-only access to the repository contents, adhering to the principle of least privilege.

The `permissions` block will be added at the root level of the workflow to apply to all jobs (`check`, `test`, and `build`). If any job requires additional permissions in the future, they can be specified within that job's configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
