### PR TITLE
Fix request header initialization

### DIFF
--- a/checker/http/http.go
+++ b/checker/http/http.go
@@ -130,6 +130,9 @@ func WithRequestBody(body io.Reader) Option {
 // WithRequestHeader configures request header
 func WithRequestHeader(key string, value []string) Option {
 	return func(h *HTTP) {
+		if h.requestHeaders == nil {
+			h.requestHeaders = http.Header{}
+		}
 		h.requestHeaders[key] = value
 	}
 }

--- a/checker/http/http_test.go
+++ b/checker/http/http_test.go
@@ -307,3 +307,22 @@ func TestHttpRequestBody(t *testing.T) {
 	err = hc.Check(context.TODO())
 	assert.Nil(t, err)
 }
+
+func TestHttpRequestHeaderWithoutInit(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		resp := new(bytes.Buffer)
+		for key, value := range r.Header {
+			fmt.Fprintf(resp, "%s=%s,", key, value)
+		}
+		w.Write(resp.Bytes())
+	}))
+	defer ts.Close()
+
+	hc := New(
+		ts.URL,
+		WithRequestHeader("Foo", []string{"Bar"}),
+		WithExpectBodyRegex("Foo=\\[Bar\\]"),
+	)
+	assert.Nil(t, hc.Check(context.TODO()))
+}


### PR DESCRIPTION
## Summary
- fix panic when using `WithRequestHeader` before initializing the header map
- add regression test for HTTP request header option

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846ea333f64832b91bdc9276f7cc8a4