### PR TITLE
Feature/Check DB Table Exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,15 +40,15 @@
 
 ## Features
 
-| Feature | Description |
-|---------|-------------|
-| **Multi-Protocol** | TCP, HTTP, DNS, and more |
-| **Service Integrations** | Redis, MySQL, PostgreSQL, MongoDB, Kafka, RabbitMQ, InfluxDB, Temporal |
-| **Reverse/Parallel Checking** | Invert checks or check multiple services at once |
-| **Exponential Backoff** | Smarter retries |
-| **Cross-Platform** | Single binary for Linux, macOS, Windows |
-| **Go Package** | Use as a Go library |
-| **Command Execution** | Run commands after checks |
+| Feature                       | Description                                                            |
+| ----------------------------- | ---------------------------------------------------------------------- |
+| **Multi-Protocol**            | TCP, HTTP, DNS, and more                                               |
+| **Service Integrations**      | Redis, MySQL, PostgreSQL, MongoDB, Kafka, RabbitMQ, InfluxDB, Temporal |
+| **Reverse/Parallel Checking** | Invert checks or check multiple services at once                       |
+| **Exponential Backoff**       | Smarter retries                                                        |
+| **Cross-Platform**            | Single binary for Linux, macOS, Windows                                |
+| **Go Package**                | Use as a Go library                                                    |
+| **Command Execution**         | Run commands after checks                                              |
 
 ## 📥 Installation
 
@@ -284,6 +284,10 @@ Check readiness for popular databases.
   ```bash
   wait4x mysql 'user:password@unix(/var/run/mysqld/mysqld.sock)/mydb'
   ```
+- **Check if a table exists:**
+  ```bash
+  wait4x mysql 'user:password@tcp(localhost:3306)/mydb' --table-exists my_table
+  ```
 
 #### PostgreSQL
 - **TCP connection:**
@@ -293,6 +297,14 @@ Check readiness for popular databases.
 - **Unix socket:**
   ```bash
   wait4x postgresql 'postgres://user:password@/mydb?host=/var/run/postgresql'
+  ```
+- **Check if a table exists:**
+  ```bash
+  wait4x postgresql 'postgres://user:password@localhost:5432/mydb?sslmode=disable' --table-exists my_table
+  ```
+  If you need to specify a schema for the table existence check, you can use the `currentSchema=myschema` connection string parameter, for example:
+  ```bash
+  wait4x postgresql 'postgres://user:password@localhost:5432/mydb?sslmode=disable&currentSchema=myschema' --table-exists my_table
   ```
 
 #### MongoDB
@@ -642,35 +654,35 @@ wait4x <command> --help
 
 ### Main Commands
 
-| Command        | Description                                       |
-|----------------|---------------------------------------------------|
-| `tcp`          | Wait for a TCP port to become available           |
-| `http`         | Wait for an HTTP(S) endpoint with advanced checks |
-| `dns`          | Wait for DNS records (A, AAAA, CNAME, MX, etc.)   |
-| `kafka`        | Wait for Kafka server                             |
-| `mysql`        | Wait for a MySQL database to be ready             |
-| `postgresql`   | Wait for a PostgreSQL database to be ready        |
-| `mongodb`      | Wait for a MongoDB database to be ready           |
-| `redis`        | Wait for a Redis server or key                    |
-| `influxdb`     | Wait for an InfluxDB server                       |
-| `rabbitmq`     | Wait for a RabbitMQ server                        |
-| `temporal`     | Wait for a Temporal server or worker              |
-| `exec`         | Wait for a shell command to succeed               |
+| Command      | Description                                       |
+| ------------ | ------------------------------------------------- |
+| `tcp`        | Wait for a TCP port to become available           |
+| `http`       | Wait for an HTTP(S) endpoint with advanced checks |
+| `dns`        | Wait for DNS records (A, AAAA, CNAME, MX, etc.)   |
+| `kafka`      | Wait for Kafka server                             |
+| `mysql`      | Wait for a MySQL database to be ready             |
+| `postgresql` | Wait for a PostgreSQL database to be ready        |
+| `mongodb`    | Wait for a MongoDB database to be ready           |
+| `redis`      | Wait for a Redis server or key                    |
+| `influxdb`   | Wait for an InfluxDB server                       |
+| `rabbitmq`   | Wait for a RabbitMQ server                        |
+| `temporal`   | Wait for a Temporal server or worker              |
+| `exec`       | Wait for a shell command to succeed               |
 
 Each command supports its own set of flags. See examples above or run `wait4x <command> --help` for details.
 
 ### Global Flags
 
-| Flag                                 | Description                                      |
-|--------------------------------------|--------------------------------------------------|
-| `--timeout`, `-t`                    | Set the maximum wait time (e.g., `30s`, `2m`)     |
-| `--interval`, `-i`                   | Set the interval between checks (default: 1s)     |
-| `--invert-check`                     | Invert the check (wait for NOT ready)             |
-| `--backoff-policy`                   | Retry policy: `linear` or `exponential`           |
-| `--backoff-exponential-coefficient`  | Exponential backoff multiplier (default: 2.0)     |
-| `--backoff-exponential-max-interval` | Max interval for exponential backoff              |
-| `--quiet`                            | Suppress output except errors                     |
-| `--no-color`                         | Disable colored output                            |
+| Flag                                 | Description                                   |
+| ------------------------------------ | --------------------------------------------- |
+| `--timeout`, `-t`                    | Set the maximum wait time (e.g., `30s`, `2m`) |
+| `--interval`, `-i`                   | Set the interval between checks (default: 1s) |
+| `--invert-check`                     | Invert the check (wait for NOT ready)         |
+| `--backoff-policy`                   | Retry policy: `linear` or `exponential`       |
+| `--backoff-exponential-coefficient`  | Exponential backoff multiplier (default: 2.0) |
+| `--backoff-exponential-max-interval` | Max interval for exponential backoff          |
+| `--quiet`                            | Suppress output except errors                 |
+| `--no-color`                         | Disable colored output                        |
 
 ### Getting Help
 

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Check readiness for popular databases.
   ```
 - **Check if a table exists:**
   ```bash
-  wait4x mysql 'user:password@tcp(localhost:3306)/mydb' --table-exists my_table
+  wait4x mysql 'user:password@tcp(localhost:3306)/mydb' --expect-table my_table
   ```
 
 #### PostgreSQL
@@ -300,11 +300,11 @@ Check readiness for popular databases.
   ```
 - **Check if a table exists:**
   ```bash
-  wait4x postgresql 'postgres://user:password@localhost:5432/mydb?sslmode=disable' --table-exists my_table
+  wait4x postgresql 'postgres://user:password@localhost:5432/mydb?sslmode=disable' --expect-table my_table
   ```
   If you need to specify a schema for the table existence check, you can use the `currentSchema=myschema` connection string parameter, for example:
   ```bash
-  wait4x postgresql 'postgres://user:password@localhost:5432/mydb?sslmode=disable&currentSchema=myschema' --table-exists my_table
+  wait4x postgresql 'postgres://user:password@localhost:5432/mydb?sslmode=disable&currentSchema=myschema' --expect-table my_table
   ```
 
 #### MongoDB

--- a/checker/mysql/mysql.go
+++ b/checker/mysql/mysql.go
@@ -27,18 +27,38 @@ import (
 
 var hidePasswordRegexp = regexp.MustCompile(`^([^:]+):[^:@]+@`)
 
+const (
+	tableExistsQuery = "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '%s')"
+)
+
 // MySQL is a MySQL checker
 type MySQL struct {
-	dsn string
+	dsn         string
+	tableExists string
 }
 
+// Option is a function that configures the MySQL checker
+type Option func(m *MySQL)
+
 // New creates a new MySQL checker
-func New(dsn string) checker.Checker {
+func New(dsn string, opts ...Option) checker.Checker {
 	m := &MySQL{
 		dsn: dsn,
 	}
 
+	// apply the list of options to MySQL
+	for _, opt := range opts {
+		opt(m)
+	}
+
 	return m
+}
+
+// WithTableExists configures the table existence check
+func WithTableExists(table string) Option {
+	return func(m *MySQL) {
+		m.tableExists = table
+	}
 }
 
 // Identity returns the identity of the MySQL checker
@@ -74,6 +94,22 @@ func (m *MySQL) Check(ctx context.Context) (err error) {
 		}
 
 		return err
+	}
+
+	// check if the table exists if option has been set
+	if m.tableExists != "" {
+		query := fmt.Sprintf(tableExistsQuery, m.tableExists)
+		var exists bool
+		err = db.QueryRowContext(ctx, query).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return checker.NewExpectedError(
+				"table does not exist", nil,
+				"table", m.tableExists,
+			)
+		}
 	}
 
 	return nil

--- a/checker/mysql/mysql.go
+++ b/checker/mysql/mysql.go
@@ -28,13 +28,13 @@ import (
 var hidePasswordRegexp = regexp.MustCompile(`^([^:]+):[^:@]+@`)
 
 const (
-	tableExistsQuery = "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '%s')"
+	expectTableQuery = "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '%s')"
 )
 
 // MySQL is a MySQL checker
 type MySQL struct {
 	dsn         string
-	tableExists string
+	expectTable string
 }
 
 // Option is a function that configures the MySQL checker
@@ -54,10 +54,10 @@ func New(dsn string, opts ...Option) checker.Checker {
 	return m
 }
 
-// WithTableExists configures the table existence check
-func WithTableExists(table string) Option {
+// WithExpectTable configures the table existence check
+func WithExpectTable(table string) Option {
 	return func(m *MySQL) {
-		m.tableExists = table
+		m.expectTable = table
 	}
 }
 
@@ -97,8 +97,8 @@ func (m *MySQL) Check(ctx context.Context) (err error) {
 	}
 
 	// check if the table exists if option has been set
-	if m.tableExists != "" {
-		query := fmt.Sprintf(tableExistsQuery, m.tableExists)
+	if m.expectTable != "" {
+		query := fmt.Sprintf(expectTableQuery, m.expectTable)
 		var exists bool
 		err = db.QueryRowContext(ctx, query).Scan(&exists)
 		if err != nil {
@@ -107,7 +107,7 @@ func (m *MySQL) Check(ctx context.Context) (err error) {
 		if !exists {
 			return checker.NewExpectedError(
 				"table does not exist", nil,
-				"table", m.tableExists,
+				"table", m.expectTable,
 			)
 		}
 	}

--- a/checker/mysql/mysql_test.go
+++ b/checker/mysql/mysql_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/log"
 	"github.com/testcontainers/testcontainers-go/modules/mysql"
+	"github.com/testcontainers/testcontainers-go/wait"
 	"wait4x.dev/v3/checker"
 )
 
@@ -39,6 +40,7 @@ func (s *MySQLSuite) SetupSuite() {
 		context.Background(),
 		"mysql:8.0.36",
 		testcontainers.WithLogger(log.TestLogger(s.T())),
+		testcontainers.WithWaitStrategy(wait.ForListeningPort("33060")),
 	)
 
 	s.Require().NoError(err)
@@ -101,7 +103,8 @@ func (s *MySQLSuite) TestTableNotExists() {
 func (s *MySQLSuite) TestExpectTable() {
 	ctx := context.Background()
 
-	s.container.Exec(ctx, []string{"mysql", "-u", "root", "-p", "password", "-e", "CREATE TABLE my_table (id INT)"})
+	_, _, err := s.container.Exec(ctx, []string{"mysql", "-u", "test", "-ptest", "-D", "test", "-e", "CREATE TABLE my_table (id INT)"})
+	s.Require().NoError(err)
 
 	endpoint, err := s.container.ConnectionString(ctx)
 	s.Require().NoError(err)

--- a/checker/mysql/mysql_test.go
+++ b/checker/mysql/mysql_test.go
@@ -94,11 +94,11 @@ func (s *MySQLSuite) TestTableNotExists() {
 	endpoint, err := s.container.ConnectionString(ctx)
 	s.Require().NoError(err)
 
-	chk := New(endpoint, WithTableExists("not_existing_table"))
+	chk := New(endpoint, WithExpectTable("not_existing_table"))
 	s.Assert().ErrorAs(chk.Check(ctx), &expectedError)
 }
 
-func (s *MySQLSuite) TestTableExists() {
+func (s *MySQLSuite) TestExpectTable() {
 	ctx := context.Background()
 
 	s.container.Exec(ctx, []string{"mysql", "-u", "root", "-p", "password", "-e", "CREATE TABLE my_table (id INT)"})
@@ -106,7 +106,7 @@ func (s *MySQLSuite) TestTableExists() {
 	endpoint, err := s.container.ConnectionString(ctx)
 	s.Require().NoError(err)
 
-	chk := New(endpoint, WithTableExists("my_table"))
+	chk := New(endpoint, WithExpectTable("my_table"))
 	s.Assert().Nil(chk.Check(ctx))
 }
 

--- a/checker/mysql/mysql_test.go
+++ b/checker/mysql/mysql_test.go
@@ -86,6 +86,30 @@ func (s *MySQLSuite) TestValidAddress() {
 	s.Assert().Nil(chk.Check(ctx))
 }
 
+func (s *MySQLSuite) TestTableNotExists() {
+	var expectedError *checker.ExpectedError
+
+	ctx := context.Background()
+
+	endpoint, err := s.container.ConnectionString(ctx)
+	s.Require().NoError(err)
+
+	chk := New(endpoint, WithTableExists("not_existing_table"))
+	s.Assert().ErrorAs(chk.Check(ctx), &expectedError)
+}
+
+func (s *MySQLSuite) TestTableExists() {
+	ctx := context.Background()
+
+	s.container.Exec(ctx, []string{"mysql", "-u", "root", "-p", "password", "-e", "CREATE TABLE my_table (id INT)"})
+
+	endpoint, err := s.container.ConnectionString(ctx)
+	s.Require().NoError(err)
+
+	chk := New(endpoint, WithTableExists("my_table"))
+	s.Assert().Nil(chk.Check(ctx))
+}
+
 // TestMySQL runs the MySQL test suite
 func TestMySQL(t *testing.T) {
 	suite.Run(t, new(MySQLSuite))

--- a/checker/postgresql/postgresql.go
+++ b/checker/postgresql/postgresql.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+
 	"wait4x.dev/v3/checker"
 
 	// Needed for the PostgreSQL driver
@@ -29,18 +30,38 @@ import (
 
 var hidePasswordRegexp = regexp.MustCompile(`^(postgres://[^/:]+):[^:@]+@`)
 
+const (
+	tableExistsQuery = "SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = '%s')"
+)
+
+// Option is a function that configures the PostgreSQL checker
+type Option func(p *PostgreSQL)
+
 // PostgreSQL is a PostgreSQL checker
 type PostgreSQL struct {
-	dsn string
+	dsn         string
+	tableExists string
 }
 
 // New creates a new PostgreSQL checker
-func New(dsn string) checker.Checker {
+func New(dsn string, opts ...Option) checker.Checker {
 	p := &PostgreSQL{
 		dsn: dsn,
 	}
 
+	// apply the list of options to PostgreSQL
+	for _, opt := range opts {
+		opt(p)
+	}
+
 	return p
+}
+
+// WithTableExists configures the table existence check
+func WithTableExists(table string) Option {
+	return func(p *PostgreSQL) {
+		p.tableExists = table
+	}
 }
 
 // Identity returns the identity of the PostgreSQL checker
@@ -76,6 +97,22 @@ func (p *PostgreSQL) Check(ctx context.Context) (err error) {
 		}
 
 		return err
+	}
+
+	// check if the table exists if option has been set
+	if p.tableExists != "" {
+		query := fmt.Sprintf(tableExistsQuery, p.tableExists)
+		var exists bool
+		err = db.QueryRowContext(ctx, query).Scan(&exists)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return checker.NewExpectedError(
+				"table does not exist", nil,
+				"table", p.tableExists,
+			)
+		}
 	}
 
 	return nil

--- a/checker/postgresql/postgresql_test.go
+++ b/checker/postgresql/postgresql_test.go
@@ -94,12 +94,12 @@ func (s *PostgreSQLSuite) TestTableNotExists() {
 	endpoint, err := s.container.ConnectionString(ctx)
 	s.Require().NoError(err)
 
-	chk := New(endpoint+"sslmode=disable", WithTableExists("not_existing_table"))
+	chk := New(endpoint+"sslmode=disable", WithExpectTable("not_existing_table"))
 
 	s.Assert().ErrorAs(chk.Check(ctx), &expectedError)
 }
 
-func (s *PostgreSQLSuite) TestTableExists() {
+func (s *PostgreSQLSuite) TestExpectTable() {
 	ctx := context.Background()
 
 	s.container.Exec(ctx, []string{"psql", "-U", "postgres", "-d", "postgres", "-c", "CREATE TABLE my_table (id INT)"})
@@ -107,7 +107,7 @@ func (s *PostgreSQLSuite) TestTableExists() {
 	endpoint, err := s.container.ConnectionString(ctx)
 	s.Require().NoError(err)
 
-	chk := New(endpoint+"sslmode=disable", WithTableExists("my_table"))
+	chk := New(endpoint+"sslmode=disable", WithExpectTable("my_table"))
 	s.Assert().Nil(chk.Check(ctx))
 }
 

--- a/checker/postgresql/postgresql_test.go
+++ b/checker/postgresql/postgresql_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/log"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
 	"wait4x.dev/v3/checker"
 )
 
@@ -39,6 +40,7 @@ func (s *PostgreSQLSuite) SetupSuite() {
 		context.Background(),
 		"postgres:16-alpine",
 		testcontainers.WithLogger(log.TestLogger(s.T())),
+		testcontainers.WithWaitStrategy(wait.ForListeningPort("5432")),
 	)
 
 	s.Require().NoError(err)
@@ -101,10 +103,10 @@ func (s *PostgreSQLSuite) TestTableNotExists() {
 
 func (s *PostgreSQLSuite) TestExpectTable() {
 	ctx := context.Background()
-
-	s.container.Exec(ctx, []string{"psql", "-U", "postgres", "-d", "postgres", "-c", "CREATE TABLE my_table (id INT)"})
-
 	endpoint, err := s.container.ConnectionString(ctx)
+	s.Require().NoError(err)
+
+	_, _, err = s.container.Exec(ctx, []string{"psql", `postgresql://postgres:postgres@localhost:5432/postgres`, "-c", "CREATE TABLE my_table (id INT)"})
 	s.Require().NoError(err)
 
 	chk := New(endpoint+"sslmode=disable", WithExpectTable("my_table"))

--- a/internal/cmd/mysql.go
+++ b/internal/cmd/mysql.go
@@ -52,7 +52,7 @@ func NewMysqlCommand() *cobra.Command {
 		RunE: runMysql,
 	}
 
-	mysqlCommand.Flags().String("table-exists", "", "Check if a table exists in the database")
+	mysqlCommand.Flags().String("expect-table", "", "Expect a table to exist in the database")
 
 	return mysqlCommand
 }

--- a/internal/cmd/mysql.go
+++ b/internal/cmd/mysql.go
@@ -68,7 +68,7 @@ func runMysql(cmd *cobra.Command, args []string) error {
 		args = args[:i]
 	}
 
-	expectTable, err := cmd.Flags().GetString("table-exists")
+	expectTable, err := cmd.Flags().GetString("expect-table")
 	if err != nil {
 		return fmt.Errorf("failed to parse --expect-table flag: %w", err)
 	}

--- a/internal/cmd/mysql.go
+++ b/internal/cmd/mysql.go
@@ -68,14 +68,14 @@ func runMysql(cmd *cobra.Command, args []string) error {
 		args = args[:i]
 	}
 
-	tableExists, err := cmd.Flags().GetString("table-exists")
+	expectTable, err := cmd.Flags().GetString("table-exists")
 	if err != nil {
-		return fmt.Errorf("failed to parse --table-exists flag: %w", err)
+		return fmt.Errorf("failed to parse --expect-table flag: %w", err)
 	}
 
 	checkers := make([]checker.Checker, len(args))
 	for i, arg := range args {
-		checkers[i] = mysql.New(arg, mysql.WithTableExists(tableExists))
+		checkers[i] = mysql.New(arg, mysql.WithExpectTable(expectTable))
 	}
 
 	return waiter.WaitParallelContext(

--- a/internal/cmd/mysql.go
+++ b/internal/cmd/mysql.go
@@ -52,6 +52,8 @@ func NewMysqlCommand() *cobra.Command {
 		RunE: runMysql,
 	}
 
+	mysqlCommand.Flags().String("table-exists", "", "Check if a table exists in the database")
+
 	return mysqlCommand
 }
 
@@ -66,9 +68,14 @@ func runMysql(cmd *cobra.Command, args []string) error {
 		args = args[:i]
 	}
 
+	tableExists, err := cmd.Flags().GetString("table-exists")
+	if err != nil {
+		return fmt.Errorf("failed to parse --table-exists flag: %w", err)
+	}
+
 	checkers := make([]checker.Checker, len(args))
 	for i, arg := range args {
-		checkers[i] = mysql.New(arg)
+		checkers[i] = mysql.New(arg, mysql.WithTableExists(tableExists))
 	}
 
 	return waiter.WaitParallelContext(

--- a/internal/cmd/postgresql.go
+++ b/internal/cmd/postgresql.go
@@ -61,9 +61,9 @@ func runPostgresql(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to get logger from context: %w", err)
 	}
 
-	tableExists, err := cmd.Flags().GetString("table-exists")
+	expectTable, err := cmd.Flags().GetString("table-exists")
 	if err != nil {
-		return fmt.Errorf("failed to parse --table-exists flag: %w", err)
+		return fmt.Errorf("failed to parse --expect-table flag: %w", err)
 	}
 
 	// ArgsLenAtDash returns -1 when -- was not specified
@@ -73,7 +73,7 @@ func runPostgresql(cmd *cobra.Command, args []string) error {
 
 	checkers := make([]checker.Checker, len(args))
 	for i, arg := range args {
-		checkers[i] = postgresql.New(arg, postgresql.WithTableExists(tableExists))
+		checkers[i] = postgresql.New(arg, postgresql.WithExpectTable(expectTable))
 	}
 
 	return waiter.WaitParallelContext(

--- a/internal/cmd/postgresql.go
+++ b/internal/cmd/postgresql.go
@@ -61,7 +61,7 @@ func runPostgresql(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to get logger from context: %w", err)
 	}
 
-	expectTable, err := cmd.Flags().GetString("table-exists")
+	expectTable, err := cmd.Flags().GetString("expect-table")
 	if err != nil {
 		return fmt.Errorf("failed to parse --expect-table flag: %w", err)
 	}

--- a/internal/cmd/postgresql.go
+++ b/internal/cmd/postgresql.go
@@ -50,6 +50,8 @@ func NewPostgresqlCommand() *cobra.Command {
 		RunE: runPostgresql,
 	}
 
+	postgresqlCommand.Flags().String("table-exists", "", "Check if a table exists in the database")
+
 	return postgresqlCommand
 }
 
@@ -59,6 +61,11 @@ func runPostgresql(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("unable to get logger from context: %w", err)
 	}
 
+	tableExists, err := cmd.Flags().GetString("table-exists")
+	if err != nil {
+		return fmt.Errorf("failed to parse --table-exists flag: %w", err)
+	}
+
 	// ArgsLenAtDash returns -1 when -- was not specified
 	if i := cmd.ArgsLenAtDash(); i != -1 {
 		args = args[:i]
@@ -66,7 +73,7 @@ func runPostgresql(cmd *cobra.Command, args []string) error {
 
 	checkers := make([]checker.Checker, len(args))
 	for i, arg := range args {
-		checkers[i] = postgresql.New(arg)
+		checkers[i] = postgresql.New(arg, postgresql.WithTableExists(tableExists))
 	}
 
 	return waiter.WaitParallelContext(

--- a/internal/cmd/postgresql.go
+++ b/internal/cmd/postgresql.go
@@ -50,7 +50,7 @@ func NewPostgresqlCommand() *cobra.Command {
 		RunE: runPostgresql,
 	}
 
-	postgresqlCommand.Flags().String("table-exists", "", "Check if a table exists in the database")
+	postgresqlCommand.Flags().String("expect-table", "", "Expect a table to exist in the database")
 
 	return postgresqlCommand
 }


### PR DESCRIPTION
Resolves #444.

- Introduced `--expect-table` option to check for the existence of a database table before completing
- Works for MySQL and Postgres
- Added tests for scenarios where a specified table exists and does not exist
