### PR TITLE
One word fix for slightly awkward phrasing

### DIFF
--- a/waiter/waiter.go
+++ b/waiter/waiter.go
@@ -190,7 +190,7 @@ func WaitContext(ctx context.Context, chk checker.Checker, opts ...Option) error
 	retries := 0
 
 	for {
-		options.logger.Info(fmt.Sprintf("[%s] Checking the %s ...", chkName, chkID))
+		options.logger.Info(fmt.Sprintf("[%s] Checking %s ...", chkName, chkID))
 
 		err := chk.Check(ctx)
 		if err != nil {

--- a/waiter/waiter_test.go
+++ b/waiter/waiter_test.go
@@ -84,7 +84,7 @@ func TestWaitLogger(t *testing.T) {
 	err := WaitContext(context.TODO(), mockChecker, WithLogger(log), WithTimeout(time.Second))
 
 	assert.Equal(t, context.DeadlineExceeded, err)
-	assert.Contains(t, buf.String(), "INFO [MockChecker] Checking the ID ...")
+	assert.Contains(t, buf.String(), "INFO [MockChecker] Checking ID ...")
 	assert.Contains(t, buf.String(), "error message")
 	mockChecker.AssertExpectations(t)
 }


### PR DESCRIPTION
Right now when running e.g. `wait4x exec true`, the output shows "Checking the true", which is awkward grammatically.

"Checking true" would be slightly better, or even better would be some message which is specific to the kind of condition being waited on ("Checking execution of true") but the latter seems more invasive of a change, so perhaps just dropping "the" is acceptable?