### PR TITLE
stop pinning wait4x.dev IPs in DNS tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,11 @@
 # syntax=docker/dockerfile:1.5.1
+
+# Global so later FROM lines can interpolate them. An ARG after COPY is
+# scoped to that stage, which made BASE_VARIANT empty and produced "runtime-".
+ARG BASE_VARIANT=alpine
+ARG ALPINE_VERSION=3.22
+ARG DEBIAN_VERSION=bookworm-slim
+
 FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.6.1 AS xx
 
 FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.22 AS base
@@ -43,10 +50,6 @@ RUN --mount=from=binary,target=/build \
 
 FROM scratch AS artifact
 COPY --from=releaser /out /
-
-ARG BASE_VARIANT=alpine
-ARG ALPINE_VERSION=3.22
-ARG DEBIAN_VERSION=bookworm-slim
 
 FROM alpine:${ALPINE_VERSION} AS runtime-alpine
 RUN apk add --update --no-cache ca-certificates tzdata

--- a/checker/dns/a/a_test.go
+++ b/checker/dns/a/a_test.go
@@ -23,8 +23,14 @@ import (
 	"wait4x.dev/v3/checker"
 )
 
-// server is the server to use for the tests
-const server = "wait4x.dev"
+const (
+	server = "wait4x.dev"
+
+	// one.one.one.one is Cloudflare DNS. Its A records are the product
+	// addresses (1.1.1.1, 1.0.0.1) and do not rotate like proxied website IPs.
+	stableHost = "one.one.one.one"
+	stableIPv4 = "1.1.1.1"
+)
 
 // TestSuite is a test suite for the A checker
 type TestSuite struct {
@@ -39,7 +45,7 @@ func (s *TestSuite) TestCheckExistenceA() {
 
 // TestCorrectA tests that the A checker correctly checks for the existence of an A record with the expected IP addresses.
 func (s *TestSuite) TestCorrectA() {
-	d := New(server, WithExpectedIPV4s([]string{"172.67.154.180", "127.0.0.1"}))
+	d := New(stableHost, WithExpectedIPV4s([]string{stableIPv4, "127.0.0.1"}))
 	s.Assert().Nil(d.Check(context.Background()))
 }
 
@@ -53,7 +59,7 @@ func (s *TestSuite) TestIncorrectA() {
 // TestCustomNSCorrectA tests that the A checker correctly checks for the existence of an A record
 // with the expected IP addresses using a custom name server.
 func (s *TestSuite) TestCustomNSCorrectA() {
-	d := New(server, WithNameServer("8.8.8.8:53"), WithExpectedIPV4s([]string{"172.67.154.180"}))
+	d := New(stableHost, WithNameServer("8.8.8.8:53"), WithExpectedIPV4s([]string{stableIPv4}))
 	s.Assert().Nil(d.Check(context.Background()))
 }
 

--- a/checker/dns/aaaa/aaaa_test.go
+++ b/checker/dns/aaaa/aaaa_test.go
@@ -23,7 +23,14 @@ import (
 	"wait4x.dev/v3/checker"
 )
 
-const server = "wait4x.dev"
+const (
+	server = "wait4x.dev"
+
+	// one.one.one.one is Cloudflare DNS. Its AAAA records are the product
+	// addresses and do not rotate like proxied website IPs.
+	stableHost = "one.one.one.one"
+	stableIPv6 = "2606:4700:4700::1111"
+)
 
 // TestSuite is a test suite for the AAAA DNS checker.
 type TestSuite struct {
@@ -40,7 +47,7 @@ func (s *TestSuite) TestCheckExistenceAAAA() {
 // TestCorrectAAAA tests that the AAAA DNS checker correctly checks for the
 // existence of the expected AAAA record for the given server.
 func (s *TestSuite) TestCorrectAAAA() {
-	d := New(server, WithExpectedIPV6s([]string{"2606:4700:3034::6815:591"}))
+	d := New(stableHost, WithExpectedIPV6s([]string{stableIPv6}))
 	s.Assert().Nil(d.Check(context.Background()))
 }
 
@@ -55,7 +62,7 @@ func (s *TestSuite) TestIncorrectAAAA() {
 // TestCustomNSCorrectAAAA tests that the AAAA DNS checker correctly checks for the
 // existence of the expected AAAA record for the given server using a custom name server.
 func (s *TestSuite) TestCustomNSCorrectAAAA() {
-	d := New(server, WithNameServer("8.8.8.8:53"), WithExpectedIPV6s([]string{"2606:4700:3034::6815:591"}))
+	d := New(stableHost, WithNameServer("8.8.8.8:53"), WithExpectedIPV6s([]string{stableIPv6}))
 	s.Assert().Nil(d.Check(context.Background()))
 }
 

--- a/checker/postgresql/postgresql_test.go
+++ b/checker/postgresql/postgresql_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/log"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"wait4x.dev/v3/checker"
 )
 
@@ -41,7 +40,9 @@ func (s *PostgreSQLSuite) SetupSuite() {
 		context.Background(),
 		"postgres:16-alpine",
 		testcontainers.WithLogger(log.TestLogger(s.T())),
-		testcontainers.WithWaitStrategy(wait.ForListeningPort("5432")),
+		// Postgres restarts after the first "ready" log. Waiting only for the
+		// port lets the first query hit a connection reset.
+		postgres.BasicWaitStrategies(),
 	)
 
 	s.Require().NoError(err)

--- a/checker/postgresql/postgresql_test.go
+++ b/checker/postgresql/postgresql_test.go
@@ -17,6 +17,7 @@ package postgresql
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -103,13 +104,23 @@ func (s *PostgreSQLSuite) TestTableNotExists() {
 
 func (s *PostgreSQLSuite) TestExpectTable() {
 	ctx := context.Background()
-	endpoint, err := s.container.ConnectionString(ctx)
+	endpoint, err := s.container.ConnectionString(ctx, "sslmode=disable")
 	s.Require().NoError(err)
 
-	_, _, err = s.container.Exec(ctx, []string{"psql", `postgresql://postgres:postgres@localhost:5432/postgres`, "-c", "CREATE TABLE my_table (id INT)"})
+	// Create the table from the host. container.Exec's error is nil when psql
+	// exits non-zero, so the previous in-container CREATE TABLE was a no-op.
+	db, err := sql.Open("postgres", endpoint)
+	s.Require().NoError(err)
+	s.T().Cleanup(func() {
+		if cerr := db.Close(); cerr != nil {
+			s.T().Errorf("close postgres: %v", cerr)
+		}
+	})
+
+	_, err = db.ExecContext(ctx, "CREATE TABLE my_table (id INT)")
 	s.Require().NoError(err)
 
-	chk := New(endpoint+"sslmode=disable", WithExpectTable("my_table"))
+	chk := New(endpoint, WithExpectTable("my_table"))
 	s.Assert().Nil(chk.Check(ctx))
 }
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -28,6 +28,14 @@ target "image-debian" {
   args = {
     BASE_VARIANT = "debian"
   }
+  // debian:bookworm-slim has no linux/arm/v6 image.
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v7",
+    "linux/arm64",
+    "linux/ppc64le",
+    "linux/s390x"
+  ]
 }
 
 // Group to build all image variants

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -28,13 +28,12 @@ target "image-debian" {
   args = {
     BASE_VARIANT = "debian"
   }
-  // debian:bookworm-slim has no linux/arm/v6 image.
+  // debian:bookworm-slim publishes amd64, arm/v7, arm64, 386, ppc64le.
   platforms = [
     "linux/amd64",
     "linux/arm/v7",
     "linux/arm64",
-    "linux/ppc64le",
-    "linux/s390x"
+    "linux/ppc64le"
   ]
 }
 

--- a/internal/cmd/dns/a.go
+++ b/internal/cmd/dns/a.go
@@ -46,17 +46,17 @@ func NewACommand() *cobra.Command {
   wait4x dns A wait4x.dev
 
   # Check A records with specific expected IPv4 addresses
-  wait4x dns A wait4x.dev --expect-ip 172.67.154.180
-  wait4x dns A wait4x.dev --expect-ip 172.67.154.180 --expect-ip 104.21.60.85
+  wait4x dns A one.one.one.one --expect-ip 1.1.1.1
+  wait4x dns A one.one.one.one --expect-ip 1.1.1.1 --expect-ip 1.0.0.1
 
   # Check A records using a custom nameserver
-  wait4x dns A wait4x.dev --expect-ip 172.67.154.180 -n gordon.ns.cloudflare.com
+  wait4x dns A one.one.one.one --expect-ip 1.1.1.1 -n 8.8.8.8
 
   # Check A records with timeout and interval settings
   wait4x dns A wait4x.dev --timeout 30s --interval 5s
 
   # Invert the check (wait until records don't match)
-  wait4x dns A wait4x.dev --expect-ip 172.67.154.180 --invert-check`,
+  wait4x dns A one.one.one.one --expect-ip 1.1.1.1 --invert-check`,
 		RunE: runA,
 	}
 

--- a/internal/cmd/dns/aaaa.go
+++ b/internal/cmd/dns/aaaa.go
@@ -45,13 +45,13 @@ func NewAAAACommand() *cobra.Command {
   wait4x dns AAAA wait4x.dev
 
   # Check AAAA records with expected IPv6 addresses
-  wait4x dns AAAA wait4x.dev --expect-ip '2606:4700:3033::ac43:9ab4'
+  wait4x dns AAAA one.one.one.one --expect-ip '2606:4700:4700::1111'
 
   # Check AAAA records with multiple expected IPv6 addresses
-  wait4x dns AAAA wait4x.dev --expect-ip '2606:4700:3033::ac43:9ab4' --expect-ip '2606:4700:3034::ac43:9ab4'
+  wait4x dns AAAA one.one.one.one --expect-ip '2606:4700:4700::1111' --expect-ip '2606:4700:4700::1001'
 
   # Check AAAA records using a specific nameserver
-  wait4x dns AAAA wait4x.dev --expect-ip '2606:4700:3033::ac43:9ab4' --nameserver gordon.ns.cloudflare.com
+  wait4x dns AAAA one.one.one.one --expect-ip '2606:4700:4700::1111' --nameserver 8.8.8.8
 
   # Check AAAA records with custom interval and timeout
   wait4x dns AAAA wait4x.dev --interval 5s --timeout 60s`,


### PR DESCRIPTION
Cloudflare rotated wait4x.dev anycast addresses,
which broke expected-IP checks and CI.