### PR TITLE
feat(docker): add non-root image variants for Alpine and Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,9 +60,16 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates tzdata \
     && rm -rf /var/lib/apt/lists/*
 
-FROM runtime-${BASE_VARIANT} AS runtime
+FROM runtime-${BASE_VARIANT} AS runtime-base
 
 COPY --from=binary /wait4x /usr/bin/wait4x
 
 ENTRYPOINT ["wait4x"]
 CMD ["help"]
+
+FROM runtime-base AS runtime-nonroot
+
+USER 65534:65534
+
+FROM runtime-base AS runtime
+

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ docker pull wait4x/wait4x:latest
 # Run the container
 docker run --rm wait4x/wait4x:latest --help
 ```
+
+For environments requiring non-root containers (e.g. Kubernetes, security compliance with Trivy / CIS Docker 4.1), use the `nonroot` tags (`nobody:nobody` / `65534:65534`):
+
+```bash
+docker pull wait4x/wait4x:nonroot
+docker pull wait4x/wait4x:debian-nonroot
+```
 </details>
 
 <details>

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,9 +1,12 @@
 // Special target: https://github.com/docker/metadata-action#bake-definition
 target "docker-metadata-action" {}
 target "docker-metadata-action-debian" {}
+target "docker-metadata-action-alpine-nonroot" {}
+target "docker-metadata-action-debian-nonroot" {}
 
 // Common configuration
 target "_common" {
+  target = "runtime"
   platforms = [
     "linux/amd64",
     "linux/arm/v6",
@@ -37,14 +40,44 @@ target "image-debian" {
   ]
 }
 
+// Alpine non-root variant
+target "image-alpine-nonroot" {
+  inherits  = ["_common", "docker-metadata-action-alpine-nonroot"]
+  target    = "runtime-nonroot"
+  args = {
+    BASE_VARIANT = "alpine"
+  }
+}
+
+// Debian non-root variant
+target "image-debian-nonroot" {
+  inherits  = ["_common", "docker-metadata-action-debian-nonroot"]
+  target    = "runtime-nonroot"
+  args = {
+    BASE_VARIANT = "debian"
+  }
+  // debian:13.6-slim publishes amd64, arm/v7, arm64, 386, ppc64le.
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v7",
+    "linux/arm64",
+    "linux/ppc64le"
+  ]
+}
+
 // Group to build all image variants
 group "image-all" {
-  targets = ["image-alpine", "image-debian"]
+  targets = ["image-alpine", "image-debian", "image-alpine-nonroot", "image-debian-nonroot"]
 }
 
 // Default image target (alpine)
 target "image" {
   inherits = ["image-alpine"]
+}
+
+// Default non-root image target (alpine non-root)
+target "image-nonroot" {
+  inherits = ["image-alpine-nonroot"]
 }
 
 target "artifact" {


### PR DESCRIPTION
### Description

Addresses #510. Adds dedicated non-root container image variants for both Alpine and Debian running as `65534:65534` (`nobody:nobody`), providing out-of-the-box compliance for Kubernetes and security scanners like Trivy (CIS Docker 4.1 / DS-0002).

### Implementation Details

1. **Dockerfile**:
   - Refactors the runtime stage into `runtime-base` and introduces `runtime-nonroot` with `USER 65534:65534`.
   - The default `runtime` stage inherits from `runtime-base`, ensuring backwards compatibility so that default builds (`:latest` and `:debian`) continue running as root.
2. **docker-bake.hcl**:
   - Configures default `target = "runtime"` in `_common`.
   - Adds `image-alpine-nonroot` and `image-debian-nonroot` bake targets targeting `runtime-nonroot`.
   - Adds targets to `image-all` and defines `image-nonroot` shortcut.
3. **README.md**:
   - Documents the `wait4x/wait4x:nonroot` and `wait4x/wait4x:debian-nonroot` tags.

### CI Workflow Configuration (.github/workflows/ci.yaml)

Due to GitHub PAT security restrictions on modifying `.github/workflows/` from personal access tokens without the `workflow` scope, the following additions can be directly added to `ci.yaml`:

```yaml
      - name: Docker metadata (Alpine Non-root)
        id: meta-alpine-nonroot
        uses: docker/metadata-action@v6
        with:
          bake-target: docker-metadata-action-alpine-nonroot
          images: | 
            atkrad/wait4x
            wait4x/wait4x
            ghcr.io/${{ github.repository }}
          flavor: |
            latest=false
            suffix=-nonroot
          tags: |
            type=raw,value=nonroot,enable={{is_default_branch}},suffix=
            type=raw,value=nonroot,enable=${{ startsWith(github.ref, 'refs/tags/v') }},suffix=
            type=semver,pattern={{version}}
            type=semver,pattern={{major}}.{{minor}}
            type=semver,pattern={{major}}
            type=ref,event=pr
            type=edge,branch=${{ github.event.repository.default_branch }}

      - name: Docker metadata (Debian Non-root)
        id: meta-debian-nonroot
        uses: docker/metadata-action@v6
        with:
          bake-target: docker-metadata-action-debian-nonroot
          images: | 
            atkrad/wait4x
            wait4x/wait4x
            ghcr.io/${{ github.repository }}
          flavor: |
            latest=false
            suffix=-debian-nonroot
          tags: |
            type=raw,value=debian-nonroot,enable={{is_default_branch}},suffix=
            type=raw,value=debian-nonroot,enable=${{ startsWith(github.ref, 'refs/tags/v') }},suffix=
            type=semver,pattern={{version}}
            type=semver,pattern={{major}}.{{minor}}
            type=semver,pattern={{major}}
            type=ref,event=pr
            type=edge,branch=${{ github.event.repository.default_branch }}

      - name: Build and push Alpine non-root image
        uses: docker/bake-action@v7
        with:
          targets: image-alpine-nonroot
          push: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
          sbom: true
          provenance: true
          files: |
            ./docker-bake.hcl
            cwd://${{ steps.meta-alpine-nonroot.outputs.bake-file }}
          set: |
            *.args.COMMIT_HASH=${{ github.sha }}
            *.args.COMMIT_REF_SLUG=${{ github.ref_name }}

      - name: Build and push Debian non-root image
        uses: docker/bake-action@v7
        with:
          targets: image-debian-nonroot
          push: ${{ github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/') }}
          sbom: true
          provenance: true
          files: |
            ./docker-bake.hcl
            cwd://${{ steps.meta-debian-nonroot.outputs.bake-file }}
          set: |
            *.args.COMMIT_HASH=${{ github.sha }}
            *.args.COMMIT_REF_SLUG=${{ github.ref_name }}
```

Closes #510.